### PR TITLE
[Story 2] DevContainer Configuration Validation

### DIFF
--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -23,8 +23,8 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin \
 ENV DOTNET_ROOT=/usr/share/dotnet
 ENV PATH="${PATH}:${DOTNET_ROOT}:${DOTNET_ROOT}/tools"
 
-# Avalonia templates
-RUN dotnet new install Avalonia.Templates::11.3.12
+# Avalonia templates (use @ syntax instead of deprecated ::)
+RUN dotnet new install Avalonia.Templates@11.3.12
 
 # Bun
 ENV BUN_INSTALL=/usr/local/bun


### PR DESCRIPTION
Implements Story 2 of Epic #3 - Phase 0: Seeding

## Summary
Validates DevContainer configuration and fixes deprecated syntax.

### Changes
- Updated Avalonia templates install command from deprecated `::` syntax to `@` syntax per .NET CLI deprecation warning

### Verification Checklist
- [x] 2.1. Dockerfile builds successfully
- [x] 2.2. DevContainer features properly configured
- [x] 2.3. opencode CLI available (v1.2.24)
- [x] 2.4. Required runtimes available (Node.js 24.14.0, .NET 10.0.102, uv 0.10.9, bun 1.3.10)
- [x] 2.5. GitHub CLI available and functional (gh 2.88.1)

### Tool Verification Results
All 8 required tools verified and working.

Addresses #3